### PR TITLE
Added automated E2E test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 README_files/
 *_files/
+__pycache__/
+*.py[cod]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -16,3 +16,8 @@ dependencies = [
     "xgboost>=3.2.0",
     "scikit-learn>=1.8.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -20,4 +20,5 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "pytest-playwright>=0.7.2",
 ]

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -297,6 +297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +537,11 @@ dependencies = [
     { name = "xgboost" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=3.1.3" },
@@ -541,6 +555,9 @@ requires-dist = [
     { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "xgboost", specifier = ">=3.2.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "markupsafe"
@@ -923,6 +940,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1005,6 +1031,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -38,6 +38,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -92,6 +101,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -294,6 +376,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
     { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
     { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -540,6 +678,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-playwright" },
 ]
 
 [package.metadata]
@@ -557,7 +696,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-playwright", specifier = ">=0.7.2" },
+]
 
 [[package]]
 name = "markupsafe"
@@ -940,6 +1082,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1016,6 +1177,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1050,6 +1223,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,6 +1260,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1102,6 +1315,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
     { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -1280,6 +1508,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1315,12 +1552,30 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]

--- a/tests/e2e/test_navigation_flow.py
+++ b/tests/e2e/test_navigation_flow.py
@@ -3,12 +3,12 @@
 
 # We test the following user workflow: A user opens the home page and can navigate from
 # the home-page cards to Explore, Predict, and Documentation. On the Explore page, the
-# snapshot cards populate and main interactive controls are visible. On the Predict page, 
-# selecting a state updates the county dropdown.
+# snapshot cards populate and main interactive controls are visible. On the Predict page,
+# selecting a state updates the county dropdown and the prediction form can be submitted.
 
 from playwright.sync_api import expect
 
-
+# Requirement: the Flask app must be running locally before the test is started.
 BASE_URL = "http://127.0.0.1:5000"
 
 
@@ -43,6 +43,18 @@ def test_user_can_navigate_from_home_cards(page):
 
     assert county_select.locator("option").count() > 1
     assert county_select.locator('option[data-state="CA"]').count() > 0
+
+    county_select.select_option("ALAMEDA COUNTY|CA")
+    page.locator('select[name="target"]').select_option("CASTHMA")
+    page.locator('select[name="scenario"]').select_option("middle_road")
+
+    page.get_by_role("button", name="Run prediction →").click()
+
+    expect(page.get_by_text("CASTHMA — ALAMEDA COUNTY, CA")).to_be_visible()
+    expect(page.get_by_text("Predicted Value (%)")).to_be_visible()
+    expect(page.get_by_text("Lower 90% CI")).to_be_visible()
+    expect(page.get_by_text("Upper 90% CI")).to_be_visible()
+    expect(page.get_by_text("There was a prediction error")).not_to_be_visible()
 
     page.goto(BASE_URL)
     page.get_by_role("link", name="ABOUT THE DATA →").click()

--- a/tests/e2e/test_navigation_flow.py
+++ b/tests/e2e/test_navigation_flow.py
@@ -1,0 +1,55 @@
+# This automated E2E test uses Playwright to validate the navigation/usage flow of the
+# entire app. More info here: https://sixfeetup.com/blog/end-to-end-testing-python-playwright.
+
+# We test the following user workflow: A user opens the home page and can navigate from
+# the home-page cards to Explore, Predict, and Documentation. On the Explore page, the
+# snapshot cards populate and main interactive controls are visible. On the Predict page, 
+# selecting a state updates the county dropdown.
+
+from playwright.sync_api import expect
+
+
+BASE_URL = "http://127.0.0.1:5000"
+
+
+
+def test_user_can_navigate_from_home_cards(page):
+    page.goto(BASE_URL)
+
+    assert page.get_by_text("Weather, health,").is_visible()
+    assert page.get_by_text("Where would you like to go?").is_visible()
+
+    page.get_by_role("link", name="EXPLORE DATA →").click()
+    page.wait_for_url(f"{BASE_URL}/explore")
+
+    assert page.get_by_text("Exploratory data analysis").is_visible()
+    expect(page.locator("#snap-states")).not_to_have_text("—")
+    expect(page.locator("#snap-counties")).not_to_have_text("—")
+    expect(page.locator("#var-health")).to_be_visible()
+    expect(page.locator("#var-weather")).to_be_visible()
+    expect(page.locator("#yr-start")).to_be_visible()
+    expect(page.locator("#yr-end")).to_be_visible()
+
+    page.goto(BASE_URL)
+    page.get_by_role("link", name="OPEN PREDICTOR →").click()
+    page.wait_for_url(f"{BASE_URL}/predict")
+
+    assert page.get_by_text("Health Outcome Predictor").is_visible()
+
+    state_select = page.locator("#stateFilter")
+    county_select = page.locator("#countySelect")
+
+    state_select.select_option("CA")
+
+    assert county_select.locator("option").count() > 1
+    assert county_select.locator('option[data-state="CA"]').count() > 0
+
+    page.goto(BASE_URL)
+    page.get_by_role("link", name="ABOUT THE DATA →").click()
+    page.wait_for_url(f"{BASE_URL}/docs")
+
+    assert page.get_by_role("heading", name="API Reference").is_visible()
+
+
+# Note: Manual checks were also implemented, i.e., non-automated navigation and clicks
+# on the website and on the different features and options.

--- a/tests/integration/test_prediction/test_prediction_page.py
+++ b/tests/integration/test_prediction/test_prediction_page.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[3] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+
+def test_predict_page_contains_pred_form():
+    client = app.test_client()
+
+    response = client.get("/predict")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert '<form action="/predict" method="POST">' in html
+
+
+def test_predict_page_contains_required_form_fields():
+    client = app.test_client()
+
+    response = client.get("/predict")
+    html = response.get_data(as_text=True)
+
+    assert 'name="county_state"' in html
+    assert 'name="target"' in html
+    assert 'name="scenario"' in html
+
+
+def test_predict_page_contains_expected_targets():
+    client = app.test_client()
+
+    response = client.get("/predict")
+    html = response.get_data(as_text=True)
+
+    assert "CASTHMA" in html
+    assert "MHLTH" in html
+    assert "PHLTH" in html
+    assert "STROKE" in html
+    assert "SLEEP" in html
+
+
+def test_predict_page_contains_expected_scenarios():
+    client = app.test_client()
+
+    response = client.get("/predict")
+    html = response.get_data(as_text=True)
+
+    assert "low_warming" in html
+    assert "middle_road" in html
+    assert "high_warming" in html
+    assert "very_high_warming" in html

--- a/tests/integration/test_routes/test_api_routes/test_map_data_api.py
+++ b/tests/integration/test_routes/test_api_routes/test_map_data_api.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[4] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+
+# Testing whether '/api/map-data' works:
+
+def test_map_data_api_returns_success_for_valid_health_var():
+    client = app.test_client()
+
+    response = client.get("/api/map-data?var=MHLTH")
+
+    assert response.status_code == 200
+
+
+def test_map_data_api_returns_expected_top_level_keys():
+    client = app.test_client()
+
+    response = client.get("/api/map-data?var=MHLTH")
+    data = response.get_json()
+
+    expected_keys = {
+        "data",
+        "health_nat_avg",
+        "weather_nat_avg",
+        "health_var",
+        "weather_var",
+        "demo_vars",
+        "year_start",
+        "year_end",
+    }
+
+    assert set(data.keys()) == expected_keys
+
+
+def test_map_data_api_returns_county_records():
+    client = app.test_client()
+
+    response = client.get("/api/map-data?var=MHLTH")
+    data = response.get_json()
+
+    assert len(data["data"]) > 0
+
+    first_record = data["data"][0]
+
+    assert "fips" in first_record
+    assert "county" in first_record
+    assert "state" in first_record
+    assert "health_val" in first_record
+    assert "population" in first_record
+
+
+def test_map_data_api_returns_400_for_invalid_health_var():
+    client = app.test_client()
+
+    response = client.get("/api/map-data?var=NOT_A_COLUMN")
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data == {"error": "Invalid variable"}

--- a/tests/integration/test_routes/test_api_routes/test_snapshot_api.py
+++ b/tests/integration/test_routes/test_api_routes/test_snapshot_api.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[4] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+
+# Testing whether '/api/snapshot' works:
+
+def test_snapshot_api_returns_success():
+    client = app.test_client()
+
+    response = client.get("/api/snapshot")
+
+    assert response.status_code == 200
+
+
+def test_snapshot_api_returns_expected_keys():
+    client = app.test_client()
+
+    response = client.get("/api/snapshot")
+    data = response.get_json()
+
+    assert set(data.keys()) == {"states", "counties", "years", "n_vars"}
+
+
+def test_snapshot_api_returns_positive_counts(): # i.e., nonempty and sensible values.
+    client = app.test_client()
+
+    response = client.get("/api/snapshot")
+    data = response.get_json()
+
+    assert data["states"] > 0
+    assert data["counties"] > 0
+    assert data["years"] > 0
+    assert data["n_vars"] > 0

--- a/tests/integration/test_routes/test_api_routes/test_summary_api.py
+++ b/tests/integration/test_routes/test_api_routes/test_summary_api.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[4] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+# Testing whether '/api/summary' works:
+
+def test_summary_api_returns_stats_for_valid_col():
+    client = app.test_client()
+
+    response = client.post("/api/summary", json={"column": "MHLTH"})
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data["column"] == "MHLTH"
+    assert "stats" in data
+    assert "mean" in data["stats"]
+
+
+def test_summary_api_returns_400_for_invalid_col():
+    client = app.test_client()
+
+    response = client.post("/api/summary", json={"column": "NOT_A_COLUMN"})
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data == {"error": "Invalid column name"}

--- a/tests/integration/test_routes/test_api_routes/test_timeseries_api.py
+++ b/tests/integration/test_routes/test_api_routes/test_timeseries_api.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[4] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+
+# Testing whether '/api/timeseries' works:
+
+def test_timeseries_api_returns_success():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries?health=MHLTH&weather=TAVG&state=all")
+
+    assert response.status_code == 200
+
+
+def test_timeseries_api_returns_health_and_weather_series():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries?health=MHLTH&weather=TAVG&state=all")
+    data = response.get_json()
+
+    assert data["state"] == "all"
+    assert "data" in data
+    assert "health" in data["data"]
+    assert "weather" in data["data"]
+
+
+def test_timeseries_api_series_contains_expected_keys():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries?health=MHLTH&weather=TAVG&state=all")
+    data = response.get_json()
+
+    health_data = data["data"]["health"]
+
+    assert "series" in health_data
+    assert "national" in health_data
+    assert "var" in health_data
+    assert "stats" in health_data
+    assert health_data["var"] == "MHLTH"
+
+
+def test_timeseries_heatmap_api_returns_success():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries/heatmap?var=MHLTH&states=CA,NY")
+
+    assert response.status_code == 200
+
+
+def test_timeseries_heatmap_api_returns_data_for_requested_states():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries/heatmap?var=MHLTH&states=CA,NY")
+    data = response.get_json()
+
+    assert data["variable"] == "MHLTH"
+    assert "data" in data
+    assert "CA" in data["data"]
+    assert "NY" in data["data"]
+
+
+def test_timeseries_heatmap_api_returns_400_for_invalid_var():
+    client = app.test_client()
+
+    response = client.get("/api/timeseries/heatmap?var=NOT_A_COLUMN")
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data == {"error": "Invalid variable"}

--- a/tests/integration/test_routes/test_basic_routes.py
+++ b/tests/integration/test_routes/test_basic_routes.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[3] / "app"
+sys.path.insert(0, str(APP_DIR))
+
+from main import app
+
+
+
+# Testing whether the main Flask pages load successfully:
+
+def test_home_route_returns_success():
+    client = app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+
+
+def test_docs_route_returns_success():
+    client = app.test_client()
+
+    response = client.get("/docs")
+
+    assert response.status_code == 200
+
+
+def test_explore_route_returns_success():
+    client = app.test_client()
+
+    response = client.get("/explore")
+
+    assert response.status_code == 200
+
+
+def test_predict_get_route_returns_success():
+    client = app.test_client()
+
+    response = client.get("/predict")
+
+    assert response.status_code == 200

--- a/tests/unit/test_assessment/test_mean_squared_error.py
+++ b/tests/unit/test_assessment/test_mean_squared_error.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from assessment import Assessment
+
+
+
+def test_mean_squared_error_expected_value():
+    assessment = Assessment()
+
+    y_true = np.array([1, 2, 3])
+    y_pred = np.array([1, 2, 5])
+
+    result = assessment.mean_squared_error(y_true, y_pred)
+
+    assert result == 4 / 3

--- a/tests/unit/test_assessment/test_r2_score.py
+++ b/tests/unit/test_assessment/test_r2_score.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from assessment import Assessment
+
+
+
+def test_r2_score_perfect_predictions():
+    assessment = Assessment()
+
+    y_true = np.array([1, 2, 3])
+    y_pred = np.array([1, 2, 3])
+
+    result = assessment.r2_score(y_true, y_pred)
+
+    assert result == 1.0

--- a/tests/unit/test_cross_validator/test_cross_validator.py
+++ b/tests/unit/test_cross_validator/test_cross_validator.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from cross_validator import CrossValidator
+from preprocessing import Preprocessor
+from splitter import Splitter
+
+
+
+class MeanModel:
+    def fit(self, X_train, y_train):
+        self.mean_ = np.mean(y_train)
+
+    def predict(self, X_val):
+        return np.full(X_val.shape[0], self.mean_)
+# We define this class because CrossValidator() expects a model object with two methods:
+# .fit() and .predict(). 
+# Does CrossValidator correctly loop through folds, preprocess data, fit a model, predict, 
+# and return MSE/R^2 scores?
+
+
+def test_cross_validator_returns_mse_and_r2_for_each_fold():
+    X = np.array([
+        [1.0],
+        [1.5],
+        [2.0],
+        [2.5],
+        [3.0],
+        [3.5],
+        [4.0],
+        [4.5],
+    ])
+
+    y = np.array([
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+    ])
+
+    years = np.array([
+        2020, 2020,
+        2021, 2021,
+        2022, 2022,
+        2023, 2023,
+    ])
+
+    splitter = Splitter(X, y, years)
+    preprocessor = Preprocessor()
+    model = MeanModel()
+    cv = CrossValidator(start_fold=0)
+
+    result = cv.cross_val_score(model, splitter, preprocessor)
+
+    assert set(result.keys()) == {"mse", "r2"}
+    assert len(result["mse"]) == 2
+    assert len(result["r2"]) == 2
+    assert all(np.isfinite(score) for score in result["mse"])
+    assert all(np.isfinite(score) for score in result["r2"])

--- a/tests/unit/test_krr/test_krr.py
+++ b/tests/unit/test_krr/test_krr.py
@@ -1,0 +1,112 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from krr import gaussian_kernel, KernelRidgeRegression
+
+
+
+def test_gaussian_kernel_returns_expected_shape():
+    X = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+    ])
+    Y = np.array([
+        [1.0, 2.0],
+        [5.0, 6.0],
+        [7.0, 8.0],
+    ])
+
+    result = gaussian_kernel(X, Y, sigma2=1.0)
+
+    assert result.shape == (2, 3)
+
+
+def test_gaussian_kernel_identical_points_have_similarity_one():
+    X = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+    ])
+
+    result = gaussian_kernel(X, X, sigma2=1.0)
+
+    np.testing.assert_allclose(np.diag(result), np.array([1.0, 1.0]))
+
+
+def test_gaussian_kernel_values_are_between_zero_and_one():
+    X = np.array([
+        [1.0],
+        [2.0],
+    ])
+
+    result = gaussian_kernel(X, X, sigma2=1.0)
+
+    assert np.all(result >= 0)
+    assert np.all(result <= 1)
+
+
+def test_krr_fit_stores_coefficients_and_train_data():
+    model = KernelRidgeRegression(lamb=1e-3, sigma2=1.0)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+
+    model.fit(X_train, y_train)
+
+    assert model.coef_ is not None
+    assert model.X_train_ is not None
+    assert model.coef_.shape == (3,)
+
+
+def test_krr_predict_returns_one_pred_per_test_row():
+    model = KernelRidgeRegression(lamb=1e-3, sigma2=1.0)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+
+    X_test = np.array([
+        [1.5],
+        [2.5],
+    ])
+
+    model.fit(X_train, y_train)
+    result = model.predict(X_test)
+
+    assert result.shape == (2,)
+
+
+def test_krr_pred_intervals_return_matching_shapes_and_ordered_bounds():
+    model = KernelRidgeRegression(lamb=1e-3, sigma2=1.0)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+
+    X_test = np.array([
+        [1.5],
+        [2.5],
+    ])
+
+    model.fit(X_train, y_train)
+    y_pred, lower, upper = model.prediction_intervals(X_test)
+
+    assert y_pred.shape == (2,)
+    assert lower.shape == (2,)
+    assert upper.shape == (2,)
+    assert np.all(lower <= y_pred)
+    assert np.all(y_pred <= upper)

--- a/tests/unit/test_preprocessing/test_detect_categorical_columns.py
+++ b/tests/unit/test_preprocessing/test_detect_categorical_columns.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from preprocessing import detect_categorical_columns
+
+
+
+def test_detect_categorical_columns_returns_indices():
+    X_df = pd.DataFrame({
+        "temperature": [10.0, 20.0, 30.0],
+        "climate_type": ["dry", "dry", "wet"],
+        "population": [100, 200, 300],
+    })
+
+    result = detect_categorical_columns(X_df)
+
+    assert result == [1]
+
+
+def test_detect_categorical_columns_returns_multiple_indices():
+    X_df = pd.DataFrame({
+        "temperature": [10.0, 20.0, 30.0],
+        "climate_type": ["dry", "dry", "wet"],
+        "region": pd.Series(["A", "B", "A"], dtype="category"),
+        "population": [100, 200, 300],
+    })
+
+    result = detect_categorical_columns(X_df)
+
+    assert result == [1, 2]
+
+
+def test_detect_categorical_columns_returns_empty_list_when_no_cat():
+    X_df = pd.DataFrame({
+        "temperature": [10.0, 20.0, 30.0],
+        "population": [100, 200, 300],
+    })
+
+    result = detect_categorical_columns(X_df)
+
+    assert result == []

--- a/tests/unit/test_preprocessing/test_one_hot_encoder.py
+++ b/tests/unit/test_preprocessing/test_one_hot_encoder.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from preprocessing import OneHotEncoder
+
+
+
+def test_one_hot_encoder_drops_first_cat_and_keeps_numeric_cols():
+    encoder = OneHotEncoder()
+
+    X = np.array([
+        [10.0, "dry"],
+        [20.0, "wet"],
+        [30.0, "dry"],
+    ], dtype=object)
+
+    result = encoder.fit_transform(X, cat_col_indices=[1])
+
+    expected = np.array([
+        [10.0, 0.0],
+        [20.0, 1.0],
+        [30.0, 0.0],
+    ])
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_one_hot_encoder_handles_multiple_cats():
+    encoder = OneHotEncoder()
+
+    X = np.array([
+        [10.0, "dry"],
+        [20.0, "wet"],
+        [30.0, "humid"],
+        [40.0, "dry"],
+    ], dtype=object)
+
+    result = encoder.fit_transform(X, cat_col_indices=[1])
+
+    expected = np.array([
+        [10.0, 0.0, 0.0],
+        [20.0, 0.0, 1.0],
+        [30.0, 1.0, 0.0],
+        [40.0, 0.0, 0.0],
+    ])
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_one_hot_encoder_unseen_cat_becomes_zero():
+    encoder = OneHotEncoder()
+
+    X_train = np.array([
+        [10.0, "dry"],
+        [20.0, "wet"],
+    ], dtype=object)
+
+    X_test = np.array([
+        [30.0, "snow"],
+    ], dtype=object)
+
+    encoder.fit(X_train, cat_col_indices=[1])
+    result = encoder.transform(X_test)
+
+    expected = np.array([
+        [30.0, 0.0],
+    ])
+
+    np.testing.assert_array_equal(result, expected)

--- a/tests/unit/test_preprocessing/test_preprocessor.py
+++ b/tests/unit/test_preprocessing/test_preprocessor.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from preprocessing import Preprocessor
+
+
+
+def test_preprocessor_num_data_imputes_and_scales():
+    preprocessor = Preprocessor()
+
+    X = np.array([
+        [1.0, 10.0],
+        [3.0, np.nan],
+        [5.0, 30.0],
+    ])
+
+    result = preprocessor.fit_transform(X)
+
+    assert result.shape == (3, 2)
+    assert np.all(np.isfinite(result))
+    np.testing.assert_allclose(result.mean(axis=0), np.array([0.0, 0.0]))
+    np.testing.assert_allclose(result.std(axis=0), np.array([1.0, 1.0]))
+
+
+def test_preprocessor_with_cat_col_returns_num_array():
+    preprocessor = Preprocessor(cat_col_indices=[1])
+
+    X = np.array([
+        [10.0, "dry"],
+        [np.nan, "wet"],
+        [30.0, "dry"],
+    ], dtype=object)
+
+    result = preprocessor.fit_transform(X)
+
+    assert result.shape == (3, 2)
+    assert np.issubdtype(result.dtype, np.number)
+    assert np.all(np.isfinite(result))
+
+
+def test_preprocessor_transform_uses_train_pipeline_on_new_data():
+    preprocessor = Preprocessor(cat_col_indices=[1])
+
+    X_train = np.array([
+        [10.0, "dry"],
+        [20.0, "wet"],
+        [30.0, "dry"],
+    ], dtype=object)
+
+    X_test = np.array([
+        [40.0, "wet"],
+    ], dtype=object)
+
+    preprocessor.fit_transform(X_train)
+    result = preprocessor.transform(X_test)
+
+    assert result.shape == (1, 2)
+    assert np.issubdtype(result.dtype, np.number)
+    assert np.all(np.isfinite(result))

--- a/tests/unit/test_preprocessing/test_simple_imputer.py
+++ b/tests/unit/test_preprocessing/test_simple_imputer.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from preprocessing import SimpleImputer
+
+
+
+def test_simple_imputer_with_nan():
+    imputer = SimpleImputer()
+
+    X = np.array([
+        [1.0, 10.0],
+        [3.0, np.nan],
+        [5.0, 30.0],
+    ])
+
+    result = imputer.fit_transform(X)
+
+    expected = np.array([
+        [1.0, 10.0],
+        [3.0, 20.0],
+        [5.0, 30.0],
+    ])
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_simple_imputer_replaces_all_nan_cols_with_zero():
+    imputer = SimpleImputer()
+
+    X = np.array([
+        [np.nan, 1.0],
+        [np.nan, 3.0],
+        [np.nan, 5.0],
+    ])
+
+    result = imputer.fit_transform(X)
+
+    expected = np.array([
+        [0.0, 1.0],
+        [0.0, 3.0],
+        [0.0, 5.0],
+    ])
+
+    np.testing.assert_array_equal(result, expected)
+    # The all-NaN imputer edge case passes, but NumPy sends a warning before the fallback in 
+    # preprocessing.py replaces the missing column mean with 0.

--- a/tests/unit/test_preprocessing/test_standard_scaler.py
+++ b/tests/unit/test_preprocessing/test_standard_scaler.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from preprocessing import StandardScaler
+
+
+
+def test_standard_scaler_transforms_via_mean_zero_and_std_one():
+    scaler = StandardScaler()
+
+    X = np.array([
+        [1.0, 10.0],
+        [2.0, 20.0],
+        [3.0, 30.0],
+    ])
+
+    result = scaler.fit_transform(X)
+
+    np.testing.assert_allclose(result.mean(axis=0), np.array([0.0, 0.0]))
+    np.testing.assert_allclose(result.std(axis=0), np.array([1.0, 1.0]))
+
+
+def test_standard_scaler_doesnt_divide_by_zero():
+    scaler = StandardScaler()
+
+    X = np.array([
+        [5.0, 1.0],
+        [5.0, 2.0],
+        [5.0, 3.0],
+    ])
+
+    result = scaler.fit_transform(X)
+
+    np.testing.assert_allclose(result[:, 0], np.array([0.0, 0.0, 0.0])) # Checks that the 
+    # constant column became all 0s.
+    assert np.all(np.isfinite(result)) # Returns False for nan, inf, or -inf.
+
+
+def test_transform_uses_train_stats():
+    scaler = StandardScaler()
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+
+    X_test = np.array([
+        [100.0],
+    ])
+
+    scaler.fit(X_train)
+    result = scaler.transform(X_test)
+
+    expected = (X_test - np.array([2.0])) / np.array([np.std([1.0, 2.0, 3.0])])
+
+    np.testing.assert_allclose(result, expected)

--- a/tests/unit/test_random_fourier_features/test_random_fourier_features.py
+++ b/tests/unit/test_random_fourier_features/test_random_fourier_features.py
@@ -1,0 +1,123 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from random_fourier_features import rff_features, RFFRidgeRegression
+
+
+
+def test_rff_features_returns_expected_shape():
+    X = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+        [5.0, 6.0],
+    ])
+
+    result = rff_features(X, R=5, sigma=1.0, seed=42)
+
+    assert result.shape == (3, 5)
+
+
+def test_rff_features_is_reproducible_with_same_seed():
+    X = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+    ])
+
+    result_1 = rff_features(X, R=4, sigma=1.0, seed=42)
+    result_2 = rff_features(X, R=4, sigma=1.0, seed=42)
+
+    np.testing.assert_array_equal(result_1, result_2)
+
+
+def test_rff_model_fit_creates_coefficients():
+    model = RFFRidgeRegression(R=5, sigma=1.0, lamb=1e-3)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+
+    model.fit(X_train, y_train)
+
+    assert model.coef_ is not None
+    assert model.coef_.shape == (5,)
+
+
+def test_rff_model_predict_returns_one_pred_per_row():
+    model = RFFRidgeRegression(R=5, sigma=1.0, lamb=1e-3)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+    X_test = np.array([
+        [4.0],
+        [5.0],
+    ])
+
+    model.fit(X_train, y_train)
+    result = model.predict(X_test)
+
+    assert result.shape == (2,)
+
+
+def test_rff_pred_interval_raises_before_calibration():
+    model = RFFRidgeRegression(R=5, sigma=1.0, lamb=1e-3)
+
+    X_train = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_train = np.array([2.0, 4.0, 6.0])
+    X_test = np.array([
+        [4.0],
+    ])
+
+    model.fit(X_train, y_train)
+
+    with pytest.raises(RuntimeError, match="calibrate"):
+        model.predict_interval(X_test)
+
+
+def test_rff_predict_interval_bounds_contain_preds():
+    model = RFFRidgeRegression(R=5, sigma=1.0, lamb=1e-3)
+
+    X_fit = np.array([
+        [1.0],
+        [2.0],
+        [3.0],
+    ])
+    y_fit = np.array([2.0, 4.0, 6.0])
+
+    X_cal = np.array([
+        [1.5],
+        [2.5],
+    ])
+    y_cal = np.array([3.0, 5.0])
+
+    X_test = np.array([
+        [4.0],
+        [5.0],
+    ])
+
+    model.fit(X_fit, y_fit)
+    model.calibrate(X_cal, y_cal)
+
+    y_pred, lower, upper = model.predict_interval(X_test)
+
+    assert y_pred.shape == (2,)
+    assert lower.shape == (2,)
+    assert upper.shape == (2,)
+    assert np.all(lower <= y_pred)
+    assert np.all(y_pred <= upper)

--- a/tests/unit/test_scenarios/test__compute_trend.py
+++ b/tests/unit/test_scenarios/test__compute_trend.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from scenarios import _compute_trend
+
+
+
+def test_compute_trend_returns_zero_when_less_than_three_rows():
+    df = pd.DataFrame({
+        "year": [2022, 2023],
+        "StateAbbr": ["CA", "CA"],
+        "County name": ["A COUNTY", "A COUNTY"],
+        "TAVG": [10.0, 12.0],
+    })
+
+    result = _compute_trend(df, "A COUNTY", "CA", "TAVG")
+
+    assert result == 0.0
+
+
+def test_compute_trend_forces_positive_slope_when_appropriate():
+    df = pd.DataFrame({
+        "year": [2021, 2022, 2023],
+        "StateAbbr": ["CA", "CA", "CA"],
+        "County name": ["A COUNTY", "A COUNTY", "A COUNTY"],
+        "TAVG": [12.0, 11.0, 10.0],
+    })
+
+    result = _compute_trend(df, "A COUNTY", "CA", "TAVG")
+
+    assert result == pytest.approx(1.0) # "approx" handles floating point imprecision.
+
+
+def test_compute_trend_forces_negative_slope_when_appropriate():
+    df = pd.DataFrame({
+        "year": [2021, 2022, 2023],
+        "StateAbbr": ["CA", "CA", "CA"],
+        "County name": ["A COUNTY", "A COUNTY", "A COUNTY"],
+        "HTDD": [40.0, 45.0, 50.0],
+    })
+
+    result = _compute_trend(df, "A COUNTY", "CA", "HTDD")
+
+    assert result == pytest.approx(-5.0) # "approx" handles floating point imprecision.

--- a/tests/unit/test_scenarios/test_generate_scenario.py
+++ b/tests/unit/test_scenarios/test_generate_scenario.py
@@ -1,0 +1,111 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from scenarios import generate_scenario
+
+
+
+def make_scenario_df():
+    return pd.DataFrame({
+        "year": [2021, 2022, 2023],
+        "StateAbbr": ["CA", "CA", "CA"],
+        "County name": ["A COUNTY", "A COUNTY", "A COUNTY"],
+        "CountyFIPS": [1, 1, 1],
+        "STATION": ["S1", "S1", "S1"],
+        "STATION_NAME": ["Station", "Station", "Station"],
+        "BPHIGH": [1.0, 1.0, 1.0],
+        "CASTHMA": [2.0, 2.0, 2.0],
+        "COPD": [3.0, 3.0, 3.0],
+        "MHLTH": [4.0, 4.0, 4.0],
+        "PHLTH": [5.0, 5.0, 5.0],
+        "SLEEP": [6.0, 6.0, 6.0],
+        "STROKE": [7.0, 7.0, 7.0],
+        "TAVG": [10.0, 11.0, 12.0],
+        "TMAX": [20.0, 21.0, 22.0],
+        "TMIN": [5.0, 6.0, 7.0],
+        "CLDD": [100.0, 110.0, 120.0],
+        "HTDD": [50.0, 45.0, 40.0],
+        "DT100": [1.0, 2.0, 3.0],
+        "DX90": [4.0, 5.0, 6.0],
+        "EMXT": [30.0, 31.0, 32.0],
+        "EMNT": [0.0, -1.0, -2.0],
+        "PRCP": [1.0, 1.0, 1.0],
+        "total_population": [1000, 1000, 1000],
+        "climate_type_short": ["dry", "dry", "dry"],
+    })
+
+
+def test_generate_scenario_returns_expected_future_years():
+    df = make_scenario_df()
+
+    X_future, future_years = generate_scenario(
+        df,
+        county_name="A COUNTY",
+        state_abbr="CA",
+        scenario_key="middle_road",
+        horizon=3,
+        baseline_yr=2023,
+    )
+
+    assert future_years == [2024, 2025, 2026]
+    assert len(X_future) == 3
+
+
+def test_generate_scenario_drops_non_feature_columns():
+    df = make_scenario_df()
+
+    X_future, _ = generate_scenario(
+        df,
+        county_name="A COUNTY",
+        state_abbr="CA",
+        scenario_key="middle_road",
+        horizon=1,
+        baseline_yr=2023,
+    )
+
+    dropped_columns = {
+        "year", "StateAbbr", "County name", "CountyFIPS",
+        "STATION", "STATION_NAME",
+        "BPHIGH", "CASTHMA", "COPD", "MHLTH", "PHLTH", "SLEEP", "STROKE",
+    }
+
+    assert dropped_columns.isdisjoint(X_future.columns)
+    assert "TAVG" in X_future.columns
+    assert "climate_type_short" in X_future.columns
+
+
+def test_generate_scenario_projects_warming_vars_forward():
+    df = make_scenario_df()
+
+    X_future, _ = generate_scenario(
+        df,
+        county_name="A COUNTY",
+        state_abbr="CA",
+        scenario_key="middle_road",
+        horizon=2,
+        baseline_yr=2023,
+    )
+
+    np.testing.assert_allclose(X_future["TAVG"].to_numpy(), np.array([13.0, 14.0]))
+    np.testing.assert_allclose(X_future["HTDD"].to_numpy(), np.array([35.0, 30.0]))
+
+
+def test_generate_scenario_raises_error_when_missing_baseline():
+    df = make_scenario_df()
+
+    with pytest.raises(ValueError, match="No data found"):
+        generate_scenario(
+            df,
+            county_name="MISSING COUNTY",
+            state_abbr="CA",
+            scenario_key="middle_road",
+            horizon=1,
+            baseline_yr=2023,
+        )

--- a/tests/unit/test_splitter/test_prepare_data.py
+++ b/tests/unit/test_splitter/test_prepare_data.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from splitter import prepare_data
+
+
+
+def test_prepare_data_keeps_target_and_drops_intended_vars():
+    df = pd.DataFrame({
+        "year": [2020, 2021],
+        "StateAbbr": ["CA", "CA"],
+        "County name": ["A", "A"],
+        "CountyFIPS": [1, 1],
+        "STATION": ["S1", "S1"],
+        "STATION_NAME": ["Station", "Station"],
+        "BPHIGH": [1.0, 2.0],
+        "CASTHMA": [3.0, 4.0],
+        "COPD": [5.0, 6.0],
+        "MHLTH": [7.0, 8.0],
+        "PHLTH": [9.0, 10.0],
+        "SLEEP": [11.0, 12.0],
+        "STROKE": [13.0, 14.0],
+        "TAVG": [70.0, 71.0],
+        "climate_type_short": ["dry", "wet"],
+    })
+
+    X, y, years = prepare_data(df, target="MHLTH")
+
+    assert "MHLTH" not in X.columns
+    assert "TAVG" in X.columns
+    assert "climate_type_short" in X.columns
+
+    dropped_columns = {
+        "StateAbbr", "County name", "CountyFIPS", "STATION", "STATION_NAME",
+        "BPHIGH", "CASTHMA", "COPD", "PHLTH", "SLEEP", "STROKE", "year",
+    }
+
+    assert dropped_columns.isdisjoint(X.columns)
+    np.testing.assert_array_equal(y, np.array([7.0, 8.0]))
+    np.testing.assert_array_equal(years, np.array([2020, 2021]))
+
+
+def test_prepare_data_drops_rows_missing_target():
+    df = pd.DataFrame({
+        "year": [2020, 2021, 2022],
+        "StateAbbr": ["CA", "CA", "CA"],
+        "County name": ["A", "A", "A"],
+        "CountyFIPS": [1, 1, 1],
+        "STATION": ["S1", "S1", "S1"],
+        "STATION_NAME": ["Station", "Station", "Station"],
+        "BPHIGH": [1.0, 2.0, 3.0],
+        "CASTHMA": [3.0, 4.0, 5.0],
+        "COPD": [5.0, 6.0, 7.0],
+        "MHLTH": [7.0, np.nan, 9.0],
+        "PHLTH": [9.0, 10.0, 11.0],
+        "SLEEP": [11.0, 12.0, 13.0],
+        "STROKE": [13.0, 14.0, 15.0],
+        "TAVG": [70.0, 71.0, 72.0],
+    })
+
+    X, y, years = prepare_data(df, target="MHLTH")
+
+    assert len(X) == 2
+    np.testing.assert_array_equal(y, np.array([7.0, 9.0]))
+    np.testing.assert_array_equal(years, np.array([2020, 2022]))

--- a/tests/unit/test_splitter/test_splitter.py
+++ b/tests/unit/test_splitter/test_splitter.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+APP_FUNCTIONS = Path(__file__).resolve().parents[3] / "app" / "functions"
+sys.path.insert(0, str(APP_FUNCTIONS))
+
+from splitter import Splitter
+
+
+
+def test_splitter_sets_train_and_test_years():
+    X = np.array([
+        [10.0],
+        [20.0],
+        [30.0],
+        [40.0],
+    ])
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    years = np.array([2020, 2021, 2022, 2023])
+
+    splitter = Splitter(X, y, years)
+
+    np.testing.assert_array_equal(splitter.train_years, np.array([2020, 2021, 2022]))
+    assert splitter.test_year == 2023
+
+
+def test_time_series_splits_expand_train_years_incrementally():
+    X = np.array([
+        [10.0],
+        [20.0],
+        [30.0],
+        [40.0],
+    ])
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    years = np.array([2020, 2021, 2022, 2023])
+
+    splitter = Splitter(X, y, years)
+    splits = splitter.time_series_splits()
+
+    assert len(splits) == 2
+
+    X_train_0, X_val_0, y_train_0, y_val_0 = splits[0]
+    np.testing.assert_array_equal(X_train_0, np.array([[10.0]]))
+    np.testing.assert_array_equal(X_val_0, np.array([[20.0]]))
+    np.testing.assert_array_equal(y_train_0, np.array([1.0]))
+    np.testing.assert_array_equal(y_val_0, np.array([2.0]))
+
+    X_train_1, X_val_1, y_train_1, y_val_1 = splits[1]
+    np.testing.assert_array_equal(X_train_1, np.array([[10.0], [20.0]]))
+    np.testing.assert_array_equal(X_val_1, np.array([[30.0]]))
+    np.testing.assert_array_equal(y_train_1, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(y_val_1, np.array([3.0]))
+
+
+def test_get_test_split_uses_last_year_as_test():
+    X = np.array([
+        [10.0],
+        [20.0],
+        [30.0],
+        [40.0],
+    ])
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    years = np.array([2020, 2021, 2022, 2023])
+
+    splitter = Splitter(X, y, years)
+
+    X_train, X_test, y_train, y_test = splitter.get_test_split()
+
+    np.testing.assert_array_equal(X_train, np.array([[10.0], [20.0], [30.0]]))
+    np.testing.assert_array_equal(X_test, np.array([[40.0]]))
+    np.testing.assert_array_equal(y_train, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(y_test, np.array([4.0]))


### PR DESCRIPTION
Hi Santiago! This adds an automated [Playwright E2E test](https://sixfeetup.com/blog/end-to-end-testing-python-playwright) covering the following workflow:

> A user opens the home page and can navigate from the home-page cards to Explore, Predict, and Documentation. On the Explore page, the snapshot cards populate and main interactive controls are visible. On the Predict page, selecting a state updates the county dropdown.

**This branch builds on the `testing-unit` branch, so the unit/integration PR should be reviewed/merged first.**

_Note:_ I also manually used the app, trying different navigation flows and clicking through different options.

Feel free to leave comments and recommendations. I might try to make the E2E testing more thorough tomorrow, but as it is quite time-consuming for me to do, I wanted to hear your thoughts first.